### PR TITLE
Fix trait definition macro

### DIFF
--- a/dilib/src/lib_macros.rs
+++ b/dilib/src/lib_macros.rs
@@ -121,7 +121,7 @@ macro_rules! add_scoped_trait {
         })
     }};
 
-     ($container:ident,  $name:literal,, $trait_type:ident $(<$($generic:ident),+>)? @ $inject_type:ty) => {{
+    ($container:ident, $name:literal, $trait_type:ident $(<$($generic:ident),+>)? @ $inject_type:ty) => {{
         $container.add_deps_fn_with_name($name, |container| -> std::boxed::Box<dyn $trait_type $(<$($generic),+>)? + Send + Sync + 'static> {
             let ret: std::boxed::Box<dyn $trait_type $(<$($generic),+>)? + Send + Sync + 'static> = {
                 let value = <$inject_type>::inject(container);


### PR DESCRIPTION
Before, the trait definition was broken if it derived inject. It's only working syntax was:
```rs
add_scoped_trait!(container, "test",, TestTrait @ TestStruct).expect("Cannot create test struct!");
```

Now, the definition is correct with the documentation above it:
```rs
add_scoped_trait!(container, "test", TestTrait @ TestStruct).expect("Cannot create test struct!");
```